### PR TITLE
Fix partial call in attachment_input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ test/dummy/log
 test/dummy/tmp
 test/dummy/public/system
 pkg
+.DS_Store

--- a/lib/simple_form_attachments/attachment_input.rb
+++ b/lib/simple_form_attachments/attachment_input.rb
@@ -234,7 +234,7 @@ module SimpleFormAttachments
       template.content_tag :div, class: container_classes do
         @builder.simple_fields_for attribute_name do |attachment_fields|
           template.render(
-            partial: File.join('simple_form_attachments', attachment_fields.object.to_partial_path), format: :html, layout: File.join('layouts', 'simple_form_attachments', 'attachment_layout'),
+            partial: attachment_fields.object.to_simple_form_partial_path, format: :html, layout: File.join('layouts', 'simple_form_attachments', 'attachment_layout'),
             locals: {
               attachment: attachment_fields.object,
               fields: attachment_fields,


### PR DESCRIPTION
While trying to override the `to_simple_form_partial_path` I found a bug 😉

Seems we used the `to_simple_form_partial_path` in the upload template, but not in the input itself.